### PR TITLE
there is no point in using tornado.gen

### DIFF
--- a/apns2/tornado_client.py
+++ b/apns2/tornado_client.py
@@ -8,7 +8,6 @@ import logging
 import pprint
 from functools import partial
 
-from tornado import gen
 from tornado.ioloop import PeriodicCallback
 from http2 import SimpleAsyncHTTP2Client
 import jwt
@@ -129,10 +128,9 @@ class APNsClient(object):
 
         return headers
 
-    @gen.coroutine
     def send_push(self, token, topic, notification, sandbox=False, priority=NOTIFICATION_PRIORITY['immediate'], expiration=None, cb=None):
         url = self.__url_pattern.format(token=token)
         json_payload = self.prepare_payload(notification)
         headers = self.prepare_headers(priority, topic, expiration)
 
-        yield self.get_conn(topic, sandbox).fetch(url, method='POST', body=json_payload, headers=headers, callback=cb, raise_error=False)
+        return self.get_conn(topic, sandbox).fetch(url, method='POST', body=json_payload, headers=headers, callback=cb, raise_error=False)


### PR DESCRIPTION
we don't do anything with result of httpclient.fetch and it does
everything we need for us. fetch returns Future, so users of send_push can
do whatever they like: yield, raise, ioloop.add_future or whatever they
like.

It even backwards compatible with old code.